### PR TITLE
Add a disable_challenge feature to ratls and examples/server

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -24,5 +24,9 @@ cargo run -- -r root-ca.crt -t token.bin
 
 __WARNING__: The X64 test host will not work fully due to [challenge
 verification](https://github.com/islet-project/ratls/blob/main/ratls/src/cert_verifier.rs#L130). If
-you need the test to pass disable the challenge verification (branch
-`disable-challenge`).
+you need the test to pass disable the challenge verification on the server with
+a `disable_challenge` feature:
+
+```
+cargo run --feature disable_challenge -- -c cert/server.crt -k cert/server.key
+```

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -10,3 +10,6 @@ clap = { version = "*", features = ["derive"] }
 log = "*"
 ratls = { path = "../../ratls" }
 # veraison-verifier = { git = "https://github.com/islet-project/veraison-verifier" }
+
+[features]
+disable_challenge = [ "ratls/disable_challenge" ]

--- a/ratls/Cargo.toml
+++ b/ratls/Cargo.toml
@@ -22,3 +22,7 @@ simple_asn1 = "*"
 x509-certificate = "*"
 rust-rsi = { git = "https://github.com/islet-project/rust-rsi" }
 rustls-webpki = "*"
+
+[features]
+# this feature is for testing purposes only, DO NOT ENABLE otherwise
+disable_challenge = []

--- a/ratls/src/cert_verifier.rs
+++ b/ratls/src/cert_verifier.rs
@@ -129,6 +129,7 @@ impl RaTlsCertVeryfier {
 
         if hash != realm_claims.challenge {
             error!("Challenge mismatch, expected: {:?} and got {:?}", self.challenge, realm_claims.challenge);
+            #[cfg(not(feature = "disable_challenge"))]
             return Err(RaTlsError::InvalidChallenge);
         }
 


### PR DESCRIPTION
This is for testing purposes only. By default it is and needs to be enabled.